### PR TITLE
Accelerate battery info fetching by caching ioreg data and querying less

### DIFF
--- a/lib/iStats/battery.rb
+++ b/lib/iStats/battery.rb
@@ -46,8 +46,8 @@ module IStats
       # Prints the battery cycle count info
       #
       def cycle_count
-        data = %x( ioreg -l | grep "CycleCount" )
-        cycle_count = data[/"CycleCount" = ([0-9]*)/, 1]
+        @ioreg_out ||= %x( ioreg -l )
+        cycle_count = @ioreg_out[/"CycleCount" = ([0-9]*)/, 1]
         if cycle_count == nil
           puts "Cycle count: unknown"
         else
@@ -62,8 +62,8 @@ module IStats
       # Get information from ioreg
       #
       def grep_ioreg(keyword)
-        data = %x( ioreg -l | grep "#{keyword}" )
-        capacity = data[/"#{keyword}" = ([0-9]*)/, 1]
+        @ioreg_out ||= %x( ioreg -l )
+        capacity = @ioreg_out[/"#{keyword}" = ([0-9]*)/, 1]
       end
 
       # Original max capacity

--- a/lib/iStats/battery.rb
+++ b/lib/iStats/battery.rb
@@ -46,7 +46,7 @@ module IStats
       # Prints the battery cycle count info
       #
       def cycle_count
-        @ioreg_out ||= %x( ioreg -l )
+        @ioreg_out ||= %x( ioreg -rn AppleSmartBattery )
         cycle_count = @ioreg_out[/"CycleCount" = ([0-9]*)/, 1]
         if cycle_count == nil
           puts "Cycle count: unknown"
@@ -62,7 +62,7 @@ module IStats
       # Get information from ioreg
       #
       def grep_ioreg(keyword)
-        @ioreg_out ||= %x( ioreg -l )
+        @ioreg_out ||= %x( ioreg -rn AppleSmartBattery )
         capacity = @ioreg_out[/"#{keyword}" = ([0-9]*)/, 1]
       end
 


### PR DESCRIPTION
This does both points mentioned in issue #20. Now on my mac, it takes only 0.109s to run `istats battery`, which is much faster than the original 2.543s.