### PR TITLE
Proper sparkline thresholds for CPU temperature in fahrenheits

### DIFF
--- a/lib/iStats/cpu.rb
+++ b/lib/iStats/cpu.rb
@@ -31,6 +31,9 @@ module IStats
         t = get_cpu_temp
         thresholds = [50, 68, 80, 90]
         value, scale = Printer.parse_temperature(t)
+        if scale == "#{Symbols.degree}F"
+          thresholds.map! { |t| Utils.to_fahrenheit(t) }
+        end
         Printer.print_item_line("CPU temp", value, scale, thresholds)
       end
     end

--- a/lib/iStats/cpu.rb
+++ b/lib/iStats/cpu.rb
@@ -31,7 +31,7 @@ module IStats
         t = get_cpu_temp
         thresholds = [50, 68, 80, 90]
         value, scale = Printer.parse_temperature(t)
-        if scale == "#{Symbols.degree}F"
+        if Printer.get_temperature_scale == 'fahrenheit'
           thresholds.map! { |t| Utils.to_fahrenheit(t) }
         end
         Printer.print_item_line("CPU temp", value, scale, thresholds)

--- a/lib/iStats/printer.rb
+++ b/lib/iStats/printer.rb
@@ -24,6 +24,10 @@ module IStats
         @display_scale = false
       end
 
+      def get_temperature_scale
+        @temperature_scale
+      end
+
       def set_temperature_scale(scale)
         @temperature_scale = scale
       end


### PR DESCRIPTION
This fixes an issue with red flashing sparkline showing up when displaying CPU temperature in fahrenheits but, at the same time, displaying the same temperature in celsius makes the sparkline green.