### PR TITLE
Allow setting of default temperature scale

### DIFF
--- a/lib/iStats/command.rb
+++ b/lib/iStats/command.rb
@@ -88,7 +88,7 @@ module IStats
           :display_graphs => true,
           :display_labels => true,
           :display_scale => true,
-          :temperature_scale => 'celcius',
+          :temperature_scale => ($config.params.dig('app_config', 'temperature_scale') || 'celcius').downcase
         }
 
         opt_parser = OptionParser.new do |opts|
@@ -122,6 +122,10 @@ module IStats
 
           opts.on('-f', '--fahrenheit', 'Display temperatures in fahrenheit') do
             options[:temperature_scale] = 'fahrenheit'
+          end
+
+          opts.on('-c', '--celcius', 'Display temperatures in celcius (default)') do
+            options[:temperature_scale] = 'celcius'
           end
         end
 
@@ -175,6 +179,7 @@ module IStats
           --no-scale                           Display just the stat value
           --value-only                         No graph, label, or scale
           -f, --fahrenheit                     Display temperatures in fahrenheit
+          -c, --celcius                        Display temperatures in celcius (default)
 
           for more help see: https://github.com/Chris911/iStats
         ".gsub(/^ {8}/, '') # strip the first eight spaces of every line

--- a/lib/iStats/version.rb
+++ b/lib/iStats/version.rb
@@ -1,3 +1,3 @@
 module IStats
-  VERSION = '1.6.1'
+  VERSION = '1.6.2'
 end


### PR DESCRIPTION
This change supports a configuration clause in `sensors.conf` that allows setting a persistent preference for temperature scale. The configuration group allows for other possible future settings to be included in it. A new command line option is added so that if `fahrenheit` is set in the configuration it can be overridden on the command line.

Example section of `sensors.conf`:

```
[app_config]
temperature_scale = fahrenheit
```

The new command line option is `-c, --celcius`. The help option has been updated to reflect the new option.