### PR TITLE
iStats #86: CFStringGetCStringPtr usually returns null.

### DIFF
--- a/ext/osx_stats/smc.c
+++ b/ext/osx_stats/smc.c
@@ -281,12 +281,23 @@ const char* getBatteryHealth() {
     if(powerSourceInformation == NULL)
         return "Unknown";
 
-    CFStringRef batteryHealthRef = (CFStringRef) CFDictionaryGetValue(powerSourceInformation, CFSTR("BatteryHealth"));
+    CFStringRef batteryHealthRef = (CFStringRef) CFDictionaryGetValue(powerSourceInformation, CFSTR(kIOPSBatteryHealthKey));
 
-    const char *batteryHealth = CFStringGetCStringPtr(batteryHealthRef, // CFStringRef theString,
-                                                kCFStringEncodingMacRoman); //CFStringEncoding encoding);
-    if(batteryHealth == NULL)
-        return "unknown";
+    const char *batteryHealth = CFStringGetCStringPtr(batteryHealthRef, kCFStringEncodingMacRoman);
+
+    if(batteryHealth == NULL) {
+        CFIndex length = CFStringGetLength(batteryHealthRef);
+        CFIndex bufSize = CFStringGetMaximumSizeForEncoding(length, kCFStringEncodingMacRoman) + 1;
+        char *buffer = (char *)malloc(bufSize);
+
+        if (CFStringGetCString(batteryHealthRef, buffer, bufSize, kCFStringEncodingMacRoman)) {
+            return buffer;
+        }
+
+        free(buffer);
+
+        return "Unknown";
+    }
 
     return batteryHealth;
 }


### PR DESCRIPTION
CFStringGetCStringPtr usually returns null. I added a fallback with CFStringGetCString to allocate a string. This is consistent and in compliance with Apple. The following link should give a bit more insight.

[CFStringGetCStringPtr Obj-C doc](https://developer.apple.com/documentation/corefoundation/1542133-cfstringgetcstringptr?language=objc)

With this fallback type of system, older systems will still behave as they did and newer ones will get the battery string the new way. Either way, it should all work the same. The only thing I'm unclear of and maybe you can help with, is how does the freeing of the pointer work? I'm not familiar with rb_str_new2, so I don't know if the GC will clean up that pointer or not.

If there's any improvements I can make or you can shed more info on how this works, that would be great. Thanks for this great little tool, you saved me plenty of time reinventing the wheel. 

p.s. Can you also give a bit more info as to how to better/quicker debug? Thanks again!