### PR TITLE
settings: enable and disable multiple keys at once

### DIFF
--- a/lib/iStats/settings.rb
+++ b/lib/iStats/settings.rb
@@ -12,13 +12,13 @@ module IStats
           if (stat[1] == 'all')
             toggleAll("1")
           else
-            set(stat[1], "1")
+            stat[1..-1].each { |x| set(x, "1") }
           end
         when 'disable'
           if (stat[1] == 'all')
             toggleAll("0")
           else
-            set(stat[1], "0")
+            stat[1..-1].each { |x| set(x, "0") }
           end
         else
           puts "Unknown command"


### PR DESCRIPTION
Like ls/rm/cp/cat, users expect these things to be able to take multiple arguments and work on each of them. It's a pain in the ass when it doesn't.